### PR TITLE
Add Ability to get CampaignMessage from Campaign 

### DIFF
--- a/src/Campaigns/Campaigns.php
+++ b/src/Campaigns/Campaigns.php
@@ -38,17 +38,31 @@ class Campaigns extends Resource
     }
 
     /**
-     * Get Campaign message
+     * Get Message from CampaignMessage
      * @see https://developers.activecampaign.com/reference#retrieve-a-campaign
      *
-     * @param int $campaignid
+     * @param int $campaignMsgid
      * @return string
      */
-    public function getMessage(int $campaignid)
+    public function getMessage(int $campaignMsgid)
     {
         $req = $this->client
             ->getClient()
-            ->get("/api/3/campaignMessages/{$campaignid}/message");
+            ->get("/api/3/campaignMessages/{$campaignMsgid}/message");
+
+        return $req->getBody()->getContents();
+    }
+
+    /**
+    * Get CampaignMessage Object
+    * @param int $campaignid
+    * @return string
+    */
+    public function getCampaignMessage(int $campaignid)
+    {
+        $req = $this->client
+        ->getClient()
+        ->get("/api/3/campaigns/{$campaignid}/campaignMessage");
 
         return $req->getBody()->getContents();
     }


### PR DESCRIPTION
Summary
---

As a part of addressing iFixit/ifixit#33568, add the ability to retrieve
CampaignMessage objects when provided a campaignid. Do this by adding
the getCampaignMessage function. This allows us to retrieve a campaign's
campaign message id, which we need in order to properly retrieve a
campaign's message.

Also, edit getMessage to reflect that it should take in a campaign
message id (not a campaign id) and that the purpose of the function is
to retrieve a Message object, not a CampaignMessage object.

QA
---
update:

There are two main options:

1) Check that previewing or accessing campaigns or campaign messages at /manage/email_manager behaves the same as it does on master. (suggested in [this comment](https://github.com/iFixit/ifixit/pull/33763#issuecomment-668835833))

**or**

2) See iFixit/ifixit/pull/33763. These two pull requests can be QA'd simultaneously.